### PR TITLE
Set :platform key on event-info map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .lein-plugins
 .lein-repl-history
 venv
+.nrepl-port

--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -17,7 +17,7 @@
   (format "Sentry sentry_version=2.0, sentry_client=raven-clj/0.6.0, sentry_timestamp=%s, sentry_key=%s, sentry_secret=%s"
           ts key secret))
 
-(defn- send-packet [{:keys [ts uri project-id key secret] :as packet-info}]
+(defn send-packet [{:keys [ts uri project-id key secret] :as packet-info}]
   (let [url (make-sentry-url uri project-id)
         header (make-sentry-header ts key secret)]
     (http/post url
@@ -43,10 +43,10 @@
   event-info is a map that should contain a :message key and optional
   keys found at http://sentry.readthedocs.org/en/latest/developer/client/index.html#building-the-json-packet"
   (send-packet
-    (merge (parse-dsn dsn)
-           {:level "error"
-            :plaform "clojure"
-            :ts (str (Timestamp. (.getTime (Date.))))}
-           event-info
-           {:event-id (generate-uuid)
-            :server-name (.getHostName (InetAddress/getLocalHost))})))
+   (merge (parse-dsn dsn)
+          {:level "error"
+           :platform "clojure"
+           :ts (str (Timestamp. (.getTime (Date.))))}
+          event-info
+          {:event-id (generate-uuid)
+           :server-name (.getHostName (InetAddress/getLocalHost))})))

--- a/test/raven_clj/core_test.clj
+++ b/test/raven_clj/core_test.clj
@@ -4,6 +4,11 @@
   (:import [java.sql Timestamp]
            [java.util Date]))
 
+(def example-dsn
+  (str "https://"
+       "b70a31b3510c4cf793964a185cfe1fd0:b7d80b520139450f903720eb7991bf3d"
+       "@example.com/1"))
+
 (deftest test-make-sentry-url
   (testing "secure url"
     (is (= (make-sentry-url "https://example.com" "1")
@@ -48,3 +53,13 @@
             :secret "b7d80b520139450f903720eb7991bf3d"
             :uri "https://example.com:9000/sentry"
             :project-id 1}))))
+
+(deftest test-capture
+  (testing "capture"
+    (testing "with a valid dsn"
+      (let [event-info (atom nil)]
+        (with-redefs [send-packet (fn [ev] (reset! event-info ev))]
+          (println @event-info)
+          (capture example-dsn {})
+          (is (= (:platform @event-info) "clojure")
+              "should set :platform in event-info to clojure"))))))


### PR DESCRIPTION
There was a typo in `capture`: we were setting the `:plaform` key rather than the `:platform` key.

I wanted to write a test to prevent the bug from reappearing, but this required `send-packet` not to be private. If this is a problem, the packet sending code could be moved from `core` to a separate namespace.
