### PR TITLE
event-id and server-name should be event_id and server_name

### DIFF
--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -48,5 +48,5 @@
            :platform "clojure"
            :ts (str (Timestamp. (.getTime (Date.))))}
           event-info
-          {:event-id (generate-uuid)
-           :server-name (.getHostName (InetAddress/getLocalHost))})))
+          {:event_id (generate-uuid)
+           :server_name (.getHostName (InetAddress/getLocalHost))})))


### PR DESCRIPTION
These keys should have underscores to enable them.

Server name now shows up in the sentry interface
