### PR TITLE
allow server_name to be overridden, e.g. to use IP

### DIFF
--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -46,7 +46,7 @@
    (merge (parse-dsn dsn)
           {:level "error"
            :platform "clojure"
+           :server_name (.getHostName (InetAddress/getLocalHost))
            :ts (str (Timestamp. (.getTime (Date.))))}
           event-info
-          {:event_id (generate-uuid)
-           :server_name (.getHostName (InetAddress/getLocalHost))})))
+          {:event_id (generate-uuid)})))


### PR DESCRIPTION
I need use IP to identify my autoscaling nodes, otherwise i get the same hostname for all.  This allows it to be overridden. 
