### PR TITLE
Stacktrace tweaks

### DIFF
--- a/src/raven_clj/interfaces.clj
+++ b/src/raven_clj/interfaces.clj
@@ -20,7 +20,7 @@
 (defn- make-frame [^StackTraceElement element]
   {:filename (.getFileName element)
    :lineno (.getLineNumber element)
-   :function (.getMethodName element)})
+   :function (str (.getClassName element) "." (.getMethodName element))})
 
 (defn- make-stacktrace-info [elements]
   {:frames (reverse (map make-frame elements))})


### PR DESCRIPTION
There are a couple of issues with stacktraces making them less useful than they could be. This PR does the following things.
1. Put most recent frames at the end
   Sentry wants them that way ("Frames should be sorted with the most recent caller being the last in the list." from http://sentry.readthedocs.org/en/5.4.5/developer/interfaces/index.html), and displays stacktraces upside-down without this change.
2. Add classname context to frames
   This changes the stacktrace output on Sentry's site from this:
   core.clj in invoke at line 2515
   to:
   core.clj in clojure.core$some.invoke at line 2515
   The updated version gives enough context to debug further.
