### PR TITLE
Support in_app field for stacktrace frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ The `capture` function is a general use function that could be placed throughout
 ;; "sentry.interfaces.Stacktrace"
 ;;  {:frames [{:filename "..." :function "..." :lineno 1}...]}
 ;; with event-info map
+;; Optionally pass your app's namespaces as the final arg to stacktrace
 (capture dsn
         (-> {:message "Test Stacktrace Exception"}
-            (interfaces/stacktrace (Exception.))))
+            (interfaces/stacktrace (Exception.) ["myapp.ns"])))
 ```
 
 #### Note about event-info map
@@ -76,9 +77,11 @@ raven-clj also includes a Ring middleware that sends the Http and Stacktrace int
     (wrap-sentry dsn)
     (handler/site))
 
-;; You could also include some of the optional attributes
+;; You could also include some of the optional attributes and pass
+;; your app's namespace prefixes so your app's stack frames are
+;; highlighted in sentry
 (-> routes
-    (wrap-sentry dsn {:tags {:version "1.0"}})
+    (wrap-sentry dsn {:tags {:version "1.0"}} ["myapp" "com.mylib"])
     (handler/site))
 ```
 

--- a/src/raven_clj/ring.clj
+++ b/src/raven_clj/ring.clj
@@ -2,19 +2,19 @@
   (:require [raven-clj.core :refer [capture]]
             [raven-clj.interfaces :refer [http stacktrace]]))
 
-(defn capture-error [dsn req extra ^Throwable error]
+(defn capture-error [dsn req extra ^Throwable error app-namespaces]
   (future (capture dsn (-> (merge extra
                                   {:message (.getMessage error)})
                            (http req)
-                           (stacktrace error)))))
+                           (stacktrace error app-namespaces)))))
 
-(defn wrap-sentry [handler dsn & [extra]]
+(defn wrap-sentry [handler dsn & [extra app-namespaces]]
   (fn [req]
     (try
       (handler req)
       (catch Exception e
-        (capture-error dsn req extra e)
+        (capture-error dsn req extra e app-namespaces)
         (throw e))
       (catch AssertionError e
-        (capture-error dsn req extra e)
+        (capture-error dsn req extra e app-namespaces)
         (throw e)))))


### PR DESCRIPTION
wrap-sentry and stacktrace now take an optional namespaces arg which
should be a list of namespace prefixes which you want to be treated as
in_app by sentry.

The stacktrace map is changed to support the exception interface.

![screenshot 2014-10-16 10 23 58](https://cloud.githubusercontent.com/assets/78506/4660778/bf31afea-551b-11e4-93dd-471a02124310.png)

![screenshot 2014-10-16 10 24 14](https://cloud.githubusercontent.com/assets/78506/4660794/dbe89b1c-551b-11e4-93d0-d75a513ad483.png)
