### PR TITLE
Update clj-http, exclude Clojure itself

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.0.1"]
-                 [clj-http "0.6.4"]
+                 [clj-http "2.0.0"]
                  [org.clojure/clojure "1.5.1"]])

--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.0.1"]
-                 [clj-http "2.0.0"]
-                 [org.clojure/clojure "1.5.1"]])
+                 [clj-http "2.0.0"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :clj-1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :clj-1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :clj-1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :clj-1.8 {:dependencies [[org.clojure/clojure "1.8.0-RC3"]]}})

--- a/test/raven_clj/core_test.clj
+++ b/test/raven_clj/core_test.clj
@@ -4,6 +4,8 @@
   (:import [java.sql Timestamp]
            [java.util Date]))
 
+(println "Testing Clojure version" (clojure-version))
+
 (def example-dsn
   (str "https://"
        "b70a31b3510c4cf793964a185cfe1fd0:b7d80b520139450f903720eb7991bf3d"


### PR DESCRIPTION
Updates to latest stable clj-http. Also removes Clojure as primary dependency, since consumers of the library will specify the version of Clojure they need in their applications.

You can run the test suite for different Clojure versions as follows:

```
lein with-profile clj-1.5 test
lein with-profile clj-1.6 test
lein with-profile clj-1.7 test
lein with-profile clj-1.8 test
```

As it happens, this library passes with versions 1.5.1 through 1.8.0-RC3.