### PR TITLE
Update link to sentry packet format doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to `capture` is `event-id` and `timestamp`.  Everything else can be overwritten 
             (interfaces/stacktrace (Exception.))))
 ```
 
-Please refer to [Building the JSON Packet](http://sentry.readthedocs.org/en/latest/developer/client/index.html#building-the-json-packet) for more information on what
+Please refer to [Building the JSON Packet](https://docs.getsentry.com/hosted/clientdev/#building-the-json-packet) for more information on what
 attributes are allowed within the packet sent to Sentry.
 
 ## Ring middleware

--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -45,7 +45,7 @@
 (defn capture [dsn event-info]
   "Send a message to a Sentry server.
   event-info is a map that should contain a :message key and optional
-  keys found at http://sentry.readthedocs.org/en/latest/developer/client/index.html#building-the-json-packet"
+  keys found at https://docs.getsentry.com/hosted/clientdev/#building-the-json-packet"
   (send-packet
    (merge (parse-dsn dsn)
           {:level "error"


### PR DESCRIPTION
The old link is dead and sentry.readthedocs.io redirects to
docs.getsentry.com now.