### PR TITLE
fix: don't send invalid attributes to sentry server

### DIFF
--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -23,13 +23,14 @@
 
 (defn send-packet [{:keys [ts uri project-id key secret] :as packet-info}]
   (let [url (make-sentry-url uri project-id)
-        header (make-sentry-header ts key secret)]
+        header (make-sentry-header ts key secret)
+        body (dissoc packet-info :ts :uri :project-id :key :secret)]
     (http/post url
                {:insecure? true
                 :throw-exceptions false
                 :headers {"X-Sentry-Auth" header
                           "User-Agent" sentry-client}
-                :body (json/generate-string packet-info)})))
+                :body (json/generate-string body)})))
 
 (defn parse-dsn [dsn]
   (let [[proto-auth url] (string/split dsn #"@")


### PR DESCRIPTION
Since 8.0 (getsentry/sentry#1746) sentry started showing messages on the
screen for invalid attributes sent in the packet.

Currently this client sends `ts`, `uri`, `project-id`, `key` and
`secret` in the body. This gets reported as an error in the UI. Prior to
8.0 the error would have just been logged and not easily visible to
users.

This PR simply `dissoc`'s the keys from the map.