### PR TITLE
Fix NPE if a frame's file path is nil

### DIFF
--- a/src/raven_clj/interfaces.clj
+++ b/src/raven_clj/interfaces.clj
@@ -22,7 +22,8 @@
          (alter-fn (make-http-info req))))
 
 (defn file->source [file-path line-number]
-  (some-> (io/resource file-path)
+  (some-> file-path
+    (io/resource)
     slurp
     (string/split #"\n")
     (#(drop (- line-number 6) %))


### PR DESCRIPTION
I've encountered a situation where `:class-path-url` is unset for one of the frames in my stack trace, which causes a NullPointerException when `file->source` is called with `nil` for the file-path argument. `io/resource` handles some cases gracefully where the argument is an empty string or a file that doesn't exist (returning `nil`) but it blows up if passed `nil` directly. This patch is a small tweak that bails early if the input itself is `nil`.