### PR TITLE
Include ex-data in the exception report

### DIFF
--- a/src/raven_clj/ring.clj
+++ b/src/raven_clj/ring.clj
@@ -2,9 +2,15 @@
   (:require [raven-clj.core :refer [capture]]
             [raven-clj.interfaces :refer [http stacktrace]]))
 
+;; Limit the size of the extra contextual data
+;; https://docs.sentry.io/clientdev/data-handling/
+(defn- truncate-extra-str [text]
+  (subs text 0 (min (count text) 4096)))
+
 (defn capture-error [dsn req ^Throwable error extra app-namespaces http-alter-fn]
   (future (capture dsn (-> (merge extra
-                                  {:message (.getMessage error)})
+                                  {:message (.getMessage error)
+                                   :extra {:ex-data (truncate-extra-str (str (ex-data error)))}})
                            (http req http-alter-fn)
                            (stacktrace error app-namespaces)))))
 


### PR DESCRIPTION
PR per our discussion in https://github.com/sethtrain/raven-clj/issues/20 to include the ex-data as an extra parameter in Sentry.