### PR TITLE
Make ring middleware a no-op with a nil DSN

### DIFF
--- a/src/raven_clj/ring.clj
+++ b/src/raven_clj/ring.clj
@@ -15,14 +15,16 @@
                            (stacktrace error app-namespaces)))))
 
 (defn wrap-sentry [handler dsn & [opts]]
-  (fn [req]
-    (let [alter-fn (or (:http-alter-fn opts)
-                       identity)]
-      (try
-        (handler req)
-        (catch Exception e
-          (capture-error dsn req e (:extra opts) (:namespaces opts) alter-fn)
-          (throw e))
-        (catch AssertionError e
-          (capture-error dsn req e (:extra opts) (:namespaces opts) alter-fn)
-          (throw e))))))
+  (if dsn
+    (fn [req]
+      (let [alter-fn (or (:http-alter-fn opts)
+                         identity)]
+        (try
+          (handler req)
+          (catch Exception e
+            (capture-error dsn req e (:extra opts) (:namespaces opts) alter-fn)
+            (throw e))
+          (catch AssertionError e
+            (capture-error dsn req e (:extra opts) (:namespaces opts) alter-fn)
+            (throw e)))))
+    handler))


### PR DESCRIPTION
I generally pull SENTRY_DSN from the environment and pass it through to `wrap-sentry` (for example, `(wrap-sentry routes (env :sentry-dsn))`). It's nice to not have to special-case it in my route definitions.