### PR TITLE
Don't send sentry_timestamp in the header.

### DIFF
--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -23,19 +23,18 @@
           uri project-id))
 
 (defn make-sentry-header
-  [ts key secret]
+  [key secret]
   (->> ["Sentry sentry_version=2.0"
         (format "sentry_client=%s" sentry-client)
-        (format "sentry_timestamp=%s" ts)
         (format "sentry_key=%s" key)
         (when secret
           (format "sentry_secret=%s" secret))]
        (remove nil?)
        (string/join ", ")))
 
-(defn send-packet [{:keys [ts uri project-id key secret] :as packet-info}]
+(defn send-packet [{:keys [uri project-id key secret] :as packet-info}]
   (let [url (make-sentry-url uri project-id)
-        header (make-sentry-header ts key secret)
+        header (make-sentry-header key secret)
         body (dissoc packet-info :ts :uri :project-id :key :secret)]
     (http/post url
                {:throw-exceptions false
@@ -67,8 +66,7 @@
    (merge (parse-dsn dsn)
           {:level "error"
            :platform "clojure"
-           :server_name (.getHostName (InetAddress/getLocalHost))
-           :ts (str (Timestamp. (.getTime (Date.))))}
+           :server_name (.getHostName (InetAddress/getLocalHost))}
           event-info
           {:event_id (generate-uuid)})))
 

--- a/test/raven_clj/core_test.clj
+++ b/test/raven_clj/core_test.clj
@@ -20,23 +20,34 @@
 
 (deftest test-make-sentry-header
   (testing "sentry header"
-    (let [ts (str (Timestamp. (.getTime (Date.))))
-          key "b70a31b3510c4cf793964a185cfe1fd0"
+    (let [key "b70a31b3510c4cf793964a185cfe1fd0"
           secret "b7d80b520139450f903720eb7991bf3d"
           client-version (version)
-          hdr (make-sentry-header ts key secret)]
+          hdr (make-sentry-header key secret)]
 
       (is (.contains hdr "sentry_version=2.0")
           "includes sentry version")
       (is (.contains hdr (str "sentry_client=raven-clj/" client-version))
           "includes client version")
-      (is (.contains hdr (format "sentry_timestamp=%s" ts))
-          "includes timestamp")
       (is (.contains hdr (str "sentry_key=" key))
           "includes key")
       (is (.contains hdr (str "sentry_secret=" secret))
           "includes secret")
-      (is (= hdr (format "Sentry sentry_version=2.0, sentry_client=raven-clj/%s, sentry_timestamp=%s, sentry_key=%s, sentry_secret=%s" client-version ts key secret))))))
+      (is (= hdr (format "Sentry sentry_version=2.0, sentry_client=raven-clj/%s, sentry_key=%s, sentry_secret=%s" client-version key secret)))))
+
+  (testing "sentry header without secret"
+    (let [key "b70a31b3510c4cf793964a185cfe1fd0"
+          secret nil
+          client-version (version)
+          hdr (make-sentry-header key secret)]
+
+      (is (.contains hdr "sentry_version=2.0")
+          "includes sentry version")
+      (is (.contains hdr (str "sentry_client=raven-clj/" client-version))
+          "includes client version")
+      (is (.contains hdr (str "sentry_key=" key))
+          "includes key")
+      (is (= hdr (format "Sentry sentry_version=2.0, sentry_client=raven-clj/%s, sentry_key=%s" client-version key secret))))))
 
 (deftest test-send-packet
   (testing "send-packet"
@@ -59,6 +70,13 @@
     (is (= (parse-dsn "https://b70a31b3510c4cf793964a185cfe1fd0:b7d80b520139450f903720eb7991bf3d@example.com/1")
            {:key "b70a31b3510c4cf793964a185cfe1fd0"
             :secret "b7d80b520139450f903720eb7991bf3d"
+            :uri "https://example.com"
+            :project-id 1})))
+
+  (testing "dsn parsing without secret"
+    (is (= (parse-dsn "https://b70a31b3510c4cf793964a185cfe1fd0@example.com/1")
+           {:key "b70a31b3510c4cf793964a185cfe1fd0"
+            :secret nil
             :uri "https://example.com"
             :project-id 1})))
 

--- a/test/raven_clj/core_test.clj
+++ b/test/raven_clj/core_test.clj
@@ -20,34 +20,40 @@
 
 (deftest test-make-sentry-header
   (testing "sentry header"
-    (let [key "b70a31b3510c4cf793964a185cfe1fd0"
+    (let [ts (.getTime (Date.))
+          key "b70a31b3510c4cf793964a185cfe1fd0"
           secret "b7d80b520139450f903720eb7991bf3d"
           client-version (version)
-          hdr (make-sentry-header key secret)]
+          hdr (make-sentry-header ts key secret)]
 
       (is (.contains hdr "sentry_version=2.0")
           "includes sentry version")
       (is (.contains hdr (str "sentry_client=raven-clj/" client-version))
           "includes client version")
+      (is (.contains hdr (format "sentry_timestamp=%d" ts))
+          "includes timestamp")
       (is (.contains hdr (str "sentry_key=" key))
           "includes key")
       (is (.contains hdr (str "sentry_secret=" secret))
           "includes secret")
-      (is (= hdr (format "Sentry sentry_version=2.0, sentry_client=raven-clj/%s, sentry_key=%s, sentry_secret=%s" client-version key secret)))))
+      (is (= hdr (format "Sentry sentry_version=2.0, sentry_client=raven-clj/%s, sentry_timestamp=%d, sentry_key=%s, sentry_secret=%s" client-version ts key secret)))))
 
   (testing "sentry header without secret"
-    (let [key "b70a31b3510c4cf793964a185cfe1fd0"
+    (let [ts (.getTime (Date.))
+          key "b70a31b3510c4cf793964a185cfe1fd0"
           secret nil
           client-version (version)
-          hdr (make-sentry-header key secret)]
+          hdr (make-sentry-header ts key secret)]
 
       (is (.contains hdr "sentry_version=2.0")
           "includes sentry version")
       (is (.contains hdr (str "sentry_client=raven-clj/" client-version))
           "includes client version")
+      (is (.contains hdr (format "sentry_timestamp=%d" ts))
+          "includes timestamp")
       (is (.contains hdr (str "sentry_key=" key))
           "includes key")
-      (is (= hdr (format "Sentry sentry_version=2.0, sentry_client=raven-clj/%s, sentry_key=%s" client-version key secret))))))
+      (is (= hdr (format "Sentry sentry_version=2.0, sentry_client=raven-clj/%s, sentry_timestamp=%d, sentry_key=%s" client-version ts key))))))
 
 (deftest test-send-packet
   (testing "send-packet"
@@ -56,7 +62,7 @@
                   :secret "secret"
                   :uri "uri"
                   :project-id "project-id"
-                  :ts "ts"}]
+                  :ts 123456789}]
       (with-redefs [http/post (fn [url opts]
                                 (reset! actual-opts opts))]
         (send-packet packet)


### PR DESCRIPTION
Previously `sentry_timestamp` in the header was sent in the format `2019-12-13 12:02:58.94`. This suddenly stopped working on 12/12 around 16:45 CST.

[Sentry's documentation](https://docs.sentry.io/development/sdk-dev/overview/) (see the Authentication section) says that the `sentry_timestamp` should be a UNIX timestamp. We tried sending `0` and that worked just fine, but we also tried not sending `sentry_timestamp` at all and that also worked.

Here is a PR removing `sentry_timestamp` from the header. What do you think?