### PR TITLE
Bump cheshire to 5.9.0

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (set-env!
  :resource-paths #{"src" "resources"}
  :dependencies '[[org.clojure/clojure "1.8.0" :scope "provided"]
-                 [cheshire "5.0.1"]
+                 [cheshire "5.9.0"]
                  [org.martinklepsch/clj-http-lite "0.4.1"]
                  [prone "1.0.1"]
 

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1" :scope "provided"]
-                 [cheshire "5.8.0"]
+                 [cheshire "5.9.0"]
                  [clj-http-lite "0.3.0"]
                  [prone "1.0.1"]])


### PR DESCRIPTION
When including the latest version of `raven-clj` (1.6.0-alpha4) I get the following error when starting my application:

```
java.lang.NoSuchMethodError: com.fasterxml.jackson.core.JsonFactory.requiresPropertyOrdering()Z
```

The underlying reason for this seems to be an old version of `cheshire`. When inspecting with `lein deps :tree`, `raven-clj` is including `cheshire` version `5.0.1`.
```
[raven-clj "1.6.0-alpha4"] -> [cheshire "5.0.1"] -> [com.fasterxml.jackson.core/jackson-core "2.1.1"]
```

When bumping this to the latest version (`[cheshire "5.9.0"]`) the issue is resolved.