### PR TITLE
Set REMOTE_ADDR in HTTP request event payload

### DIFF
--- a/src/raven_clj/interfaces.clj
+++ b/src/raven_clj/interfaces.clj
@@ -15,7 +15,8 @@
    :headers (get req :headers {})
    :query_string (get req :query-string "")
    :data (get req :params {})
-   :env {:session (get req :session {})}})
+   :env {:session (get req :session {})
+         "REMOTE_ADDR" (get req :remote-addr "")}})
 
 (defn http [event-map req alter-fn]
   (assoc event-map "sentry.interfaces.Http"


### PR DESCRIPTION
The Sentry event payload supports `REMOTE_ADDR` under the `env` key: 
* https://develop.sentry.dev/sdk/event-payloads/request/
* https://develop.sentry.dev/sdk/event-payloads/types/#request

The `:remote-addr` key can be added to ring requests using
`ring.middleware.proxy-headers` from `ring/ring-headers:0.3.0` that is
e.g. enabled with `(ring-defaults/wrap-defaults ,,, {:proxy true})` from
`ring/ring-defaults:0.3.4`.

If `:remote-addr` is not present in the request, we send the empty string
and Sentry will not show this field in its web UI.