### PR TITLE
Update HTTP interface key

### DIFF
--- a/src/raven_clj/interfaces.clj
+++ b/src/raven_clj/interfaces.clj
@@ -18,8 +18,7 @@
    :env {:session (get req :session {})}})
 
 (defn http [event-map req alter-fn]
-  (assoc event-map "sentry.interfaces.Http"
-         (alter-fn (make-http-info req))))
+  (assoc event-map :request (alter-fn (make-http-info req))))
 
 (defn file->source [file-path line-number]
   (some-> file-path


### PR DESCRIPTION
Sentry documents its HTTP interface name as `request` instead of `sentry.interfaces.Http`:
* https://develop.sentry.dev/sdk/event-payloads/request/
* https://develop.sentry.dev/sdk/event-payloads/types/#request