### PR TITLE
Add `clojure.lang.ExceptionInfo`'s `ex-data` where available

### DIFF
--- a/src/raven_clj/interfaces.clj
+++ b/src/raven_clj/interfaces.clj
@@ -42,6 +42,11 @@
      :pre_context  (take 5 source)
      :post_context (drop 6 source)}))
 
+(defn- flatten-data [data]
+  (into {} (map (fn [[k v]]
+                  [(pr-str k) (pr-str v)])
+                data)))
+
 (defn stacktrace [event-map ^Exception e & [app-namespaces]]
   (let [stacks  (prone-stack/normalize-exception (clj-stack/root-cause e))
         frames  (map (partial frame->sentry app-namespaces)
@@ -49,4 +54,6 @@
     (assoc event-map
       :exception [{:value      (:message stacks)
                    :type       (:type stacks)
-                   :stacktrace {:frames frames}}])))
+                   :stacktrace {:frames frames}
+                   :mechanism  (cond-> {:type "generic"}
+                                       (:data stacks) (assoc :data (flatten-data (:data stacks))))}])))


### PR DESCRIPTION
`prone.stacks/normalize-exception`, via `prone.stacks/add-data` sets
a `clojure.lang.ExceptionInfo`'s `ex-data` as `:data` on the normalized
exception.  This data is generally useful, so pass it on to Sentry via
the `mechanism.data` key of the `exception` payload:
* https://develop.sentry.dev/sdk/event-payloads/exception/#exception-mechanism

Since Sentry does not support nested maps (it will not display the data at all
in that case), we flatten the data using `pr-str`.