### PR TITLE
readme: fix cljdoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# raven-clj [![raven cljdoc badge](https://cljdoc.xyz/badge/raven-clj)](https://cljdoc.xyz/d/raven-clj/raven-clj/CURRENT)
+# raven-clj [![raven cljdoc badge](https://cljdoc.org/badge/raven-clj)](https://cljdoc.org/d/raven-clj/raven-clj/CURRENT)
 
 A Clojure interface to Sentry.
 


### PR DESCRIPTION
cljdoc.xyz was an initial test server that was retired some time ago.